### PR TITLE
Remove org-public-id from Member operations

### DIFF
--- a/lib/ex_clubhouse/api/member.ex
+++ b/lib/ex_clubhouse/api/member.ex
@@ -30,21 +30,21 @@ defmodule ExClubhouse.Api.Member do
       iex> ExClubhouse.Api.Member.list()
       {:ok, [%ExClubhouse.Model.Member{...}, ...]}
   """
-  @spec list(binary) :: {:ok, [ExClubhouse.Model.Member.t()]} | {:error, ExClubhouse.Error.t()}
-  def list(org_public_id) do
-    Config.default() |> Session.from() |> list(org_public_id)
+  @spec list() :: {:ok, [ExClubhouse.Model.Member.t()]} | {:error, ExClubhouse.Error.t()}
+  def list do
+    Config.default() |> Session.from() |> list()
   end
 
   @doc """
-  Get a single LinkedFile by id
+  Get a single Member by id
 
   ## Example
-      iex> ExClubhouse.Api.Member.get("1", "2")
+      iex> ExClubhouse.Api.Member.get("1")
       {:ok, %ExClubhouse.Model.Member{...}}
   """
-  @spec get(binary, binary) :: {:ok, ExClubhouse.Model.Member.t() | nil} | {:error, ExClubhouse.Error.t()}
-  def get(org_public_id, member_public_id) do
-    Config.default() |> Session.from() |> get(org_public_id, member_public_id)
+  @spec get(binary) :: {:ok, ExClubhouse.Model.Member.t() | nil} | {:error, ExClubhouse.Error.t()}
+  def get(member_public_id) do
+    Config.default() |> Session.from() |> get(member_public_id)
   end
 
   ##################################
@@ -58,13 +58,13 @@ defmodule ExClubhouse.Api.Member do
     |> Parser.parse()
   end
 
-  @spec get(ExClubhouse.Session.t(), binary(), binary()) :: {:ok, [ExClubhouse.Model.Member.t()]} | {:error, ExClubhouse.Error.t()}
-  def get(%Session{} = session, org_public_id, member_public_id) do
-    Ops.Member.get(org_public_id, member_public_id) |> Client.HTTP.request(session) |> Parser.parse()
+  @spec get(ExClubhouse.Session.t(), binary()) :: {:ok, [ExClubhouse.Model.Member.t()]} | {:error, ExClubhouse.Error.t()}
+  def get(%Session{} = session, member_public_id) do
+    Ops.Member.get(member_public_id) |> Client.HTTP.request(session) |> Parser.parse()
   end
 
-  @spec list(ExClubhouse.Session.t(), binary()) :: {:ok, [ExClubhouse.Model.Member.t()]} | {:error, ExClubhouse.Error.t()}
-  def list(%Session{} = session, org_public_id) do
-    Ops.Member.list(org_public_id) |> Client.HTTP.request(session) |> Parser.parse()
+  @spec list(ExClubhouse.Session.t()) :: {:ok, [ExClubhouse.Model.Member.t()]} | {:error, ExClubhouse.Error.t()}
+  def list(%Session{} = session) do
+    Ops.Member.list() |> Client.HTTP.request(session) |> Parser.parse()
   end
 end

--- a/lib/ex_clubhouse/ops/member.ex
+++ b/lib/ex_clubhouse/ops/member.ex
@@ -14,24 +14,20 @@ defmodule ExClubhouse.Ops.Member do
     }
   end
 
-  @spec list(binary()) :: ExClubhouse.Operation.t()
-  def list(org_public_id) do
+  @spec list() :: ExClubhouse.Operation.t()
+  def list do
     %Operation{
       id: :member_list,
       method: :get,
-      path: "members",
-      body: %{
-        "org-public-id" => org_public_id
-      }
+      path: "members"
     }
   end
 
-  @spec get(binary(), binary()) :: ExClubhouse.Operation.t()
-  def get(org_public_id, member_public_id) do
+  @spec get(binary()) :: ExClubhouse.Operation.t()
+  def get(member_public_id) do
     %Operation{
       id: :member_get,
       method: :get,
-      body: %{"org-public-id" => org_public_id},
       path: "members/#{member_public_id}"
     }
   end

--- a/test/api/member_test.exs
+++ b/test/api/member_test.exs
@@ -28,16 +28,13 @@ defmodule ExClubhouse.Api.MemberTest do
         ResponseBuilder.build_response("test/fixtures/member/list_ok.json")
       end)
 
-      org_id = 123
-      member_id = "12345678-9012-3456-7890-123456789012"
-
       assert {:ok,
               [
                 %Model.Member{
-                  id: ^member_id,
+                  id: "12345678-9012-3456-7890-123456789012",
                   role: "foo"
                 }
-              ]} = Member.list(org_id)
+              ]} = Member.list()
     end
   end
 
@@ -48,14 +45,13 @@ defmodule ExClubhouse.Api.MemberTest do
         ResponseBuilder.build_response("test/fixtures/member/get_ok.json")
       end)
 
-      org_id = 123
       member_id = "12345678-9012-3456-7890-123456789012"
 
       assert {:ok,
               %Model.Member{
                 id: ^member_id,
                 role: "foo"
-              }} = Member.get(org_id, member_id)
+              }} = Member.get(member_id)
     end
   end
 end


### PR DESCRIPTION
After hitting a roadblock and communicating with Clubhouse support it appears that the `org-public-id` parameter featured in Member requests is no longer in use. This PR removes `org-public-id`, restoring the ability to both list members and get a member.
  
## Background
  
When using ExClubhouse to fetch member data from the Clubhouse API I was required to pass in the `org-public-id` for both _List Members_ and _Get Member_ operations, consistent with the Clubhouse REST API v3 documentation: [List Members](https://clubhouse.io/api/rest/v3/#List-Members); [Get Member](https://clubhouse.io/api/rest/v3/#Get-Member).

After a thorough search of the Clubhouse Workspace, and upon finding nothing resembling an `org-public-id`, I contacted Clubhouse Support and got the following response:
  
> You won't need the Organization ID as long as you're using the API with your token. The API is scoped to work for the entire Workspace based on your API key, and this is a section of our documentation that we'll make sure to improve  
—Clubhouse Support, _Nov 16, 2020, 12:35 PM EST_
  
I tested both operations with **curl** omitting the `org-public-id` (requests below) and both returned successfully with the same JSON shape as that listed in the ExClubhouse test fixtures: [`member/list_ok.json`](https://github.com/humberaquino/exclubhouse/blob/223ad2e1c4598c34b6405d8bb7f6275a034611b7/test/fixtures/member/list_ok.json), [`member/get_ok.json`](https://github.com/humberaquino/exclubhouse/blob/223ad2e1c4598c34b6405d8bb7f6275a034611b7/test/fixtures/member/get_ok.json)

  
    curl -X GET \
      -H "Content-Type: application/json" \
      -H "Clubhouse-Token: <REDACTED>" \
      -L "https://api.clubhouse.io/api/v3/members"
  
    curl -X GET \
      -H "Content-Type: application/json" \
      -H "Clubhouse-Token: <REDACTED>" \
      -L "https://api.clubhouse.io/api/v3/members/54321234-0c02-4874-b067-6ca0dbb9c5f5"
  
## Extra
  
I’m fairly new to the Elixir world but this library is one of the most well put together I’ve seen. I really like how it’s split up into clear responsibilities. Clean and flexible! Thank you.
